### PR TITLE
Gracefully handle 0 byte files

### DIFF
--- a/persist-properties.lua
+++ b/persist-properties.lua
@@ -42,6 +42,10 @@ local function load_config(file)
         local jsonString = f:read()
         f:close()
 
+        if jsonString == nil then
+            return {}
+        end
+
         local props = utils.parse_json(jsonString)
         if props then
             return props


### PR DESCRIPTION
It's possible that when opening multiple mpv instances, persistent_config.json ends up completely empty.
The script spits out an error and stops on every subsequent launch until the user deletes their persistent_config file.
```
[persist_properties] 
[persist_properties] stack traceback:                                                                                                                                                                             
[persist_properties]    [C]: in function 'parse_json'                                                                                                                                                             
[persist_properties]    [string "/home/eva/.config/mpv/scripts/persist-propert..."]:45: in function 'load_config'                                                                                                 
[persist_properties]    [string "/home/eva/.config/mpv/scripts/persist-propert..."]:69: in function 'onInitialLoad'                                                                                               
[persist_properties]    [string "/home/eva/.config/mpv/scripts/persist-propert..."]:105: in main chunk                                                                                                            
[persist_properties]    [C]: in ?                                                                                                                                                                                 
[persist_properties]    [C]: in ?                                                                                                                                                                                 
[persist_properties] Lua error: bad argument #1 to '?' (string expected, got nil)
```
This PR is a simple fix for that.